### PR TITLE
(Bugfix) Resolves missing forge tags

### DIFF
--- a/forge/src/main/resources/data/forge/tags/blocks/fence_gates/wooden.json
+++ b/forge/src/main/resources/data/forge/tags/blocks/fence_gates/wooden.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "bambooeverything:bamboo_fence_gate"
+  ]
+}

--- a/forge/src/main/resources/data/forge/tags/blocks/fences/wooden.json
+++ b/forge/src/main/resources/data/forge/tags/blocks/fences/wooden.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "bambooeverything:bamboo_fence"
+  ]
+}


### PR DESCRIPTION
Changes:
  - N/A

Adds:
  - Support for '#forge:fences/wooden' tag
  - Support for '#forge:fence_gates/wooden' tag

Removes:
   - N/A